### PR TITLE
use `:nth-child` to stripe list

### DIFF
--- a/Yogo_Syu/CSS/style.css
+++ b/Yogo_Syu/CSS/style.css
@@ -13,10 +13,10 @@
     grid-gap: 5px;
 }
 
-.yogoEven {
+.yogo:nth-child(even) {
     background-color: #fad0fa;
 }
-.yogoOdd {
+.yogo:nth-child(odd) {
     background-color: #f995f9;
 }
 

--- a/Yogo_Syu/index.html
+++ b/Yogo_Syu/index.html
@@ -50,7 +50,7 @@
 
 
 		<div class="yogoWrapper">
-			<div class="yogoOdd">
+			<div class="yogo">
 				<div class="yogoTitle">
 					ぎちゃんぎちゃん
 				</div>
@@ -61,7 +61,7 @@
 				</div>
 			</div>
 
-			<div class="yogoEven">
+			<div class="yogo">
 				<div class="yogoTitle">
 					凸アル
 				</div>


### PR DESCRIPTION
しましまにするのに CSS の [`:nth-child`](https://developer.mozilla.org/ja/docs/Web/CSS/:nth-child) 疑似要素を使用した

さぁ〜しましまっちゃうからね〜
![image](https://user-images.githubusercontent.com/14973783/118518797-74955d80-b773-11eb-9e16-43aa514538b4.png)
